### PR TITLE
Add auth_scheme param to client options in strategy

### DIFF
--- a/lib/omniauth/strategies/instagram_basic.rb
+++ b/lib/omniauth/strategies/instagram_basic.rb
@@ -7,7 +7,7 @@ module OmniAuth
       TOKEN_PATH = 'oauth/access_token'.freeze
       TOKEN_OPTIONS = ["client_id", "client_secret"].freeze
 
-      option :client_options, site: SITE_URL, token_url: TOKEN_PATH
+      option :client_options, site: SITE_URL, token_url: TOKEN_PATH, auth_scheme: :request_body
       option :token_options, TOKEN_OPTIONS
       option :name, 'instagram_basic'
 
@@ -37,7 +37,7 @@ module OmniAuth
         url = "https://graph.instagram.com/me? \
                 fields=id,account_type,media_count,username \
                 &access_token=#{access_token.token}"
-        
+
         @raw_info ||= access_token.get(url).parsed || {}
       end
 


### PR DESCRIPTION
Should address the problem of `Authentication failure! invalid_credentials: OAuth2::Error, invalid_request: Missing required parameter: client_id. {"error":"invalid_request","error_description":"Missing required parameter: client_id."}` when trying to fetch Instagram basic using Omniauth in combination with Devise.

Details are mentioned [here](https://github.com/omniauth/omniauth/issues/1101#issuecomment-1490215761).